### PR TITLE
fix/syntax-error on ./index.js

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,4 +1,4 @@
-exports.handler = function (event) {
+export const handler = function (event) {
   if (event?.name) {  // Did the function receive an argument with a name field?
     console.info(`Hello, ${event.name}!`);
   }


### PR DESCRIPTION
solves the error "SyntaxError: The requested module './index.js' does not provide an export named 'handler'"